### PR TITLE
fix: #19 falling back to classic code block formatting for hover

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -1,8 +1,6 @@
 name: Check
 
 on:
-  pull_request:
-    types: [opened, reopened, synchronize]
   pull_request_target:
     types: [opened, reopened, synchronize]
     branches:

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,7 +9,10 @@
       "name": "Run Extension",
       "type": "extensionHost",
       "request": "launch",
-      "args": ["--extensionDevelopmentPath=${workspaceFolder}"],
+      "args": [
+        "--extensionDevelopmentPath=${workspaceFolder}",
+        "--disable-extensions"
+      ],
       "outFiles": ["${workspaceFolder}/dist/**/*.js"],
       "preLaunchTask": "${defaultBuildTask}"
     },

--- a/examples/react-app/src/test/SyntaxHighlight.tsx
+++ b/examples/react-app/src/test/SyntaxHighlight.tsx
@@ -1,0 +1,5 @@
+import styles from "./styles/SyntaxHighlight.module.scss";
+
+export default function SyntaxHighlight() {
+  return <div className={styles.bodyBold}></div>;
+}

--- a/examples/react-app/src/test/styles/SyntaxHighlight.module.scss
+++ b/examples/react-app/src/test/styles/SyntaxHighlight.module.scss
@@ -1,0 +1,8 @@
+.bodyBold {
+    display: flex;
+
+    & h2 {
+        // abc
+        padding: 0 40px;
+    }
+}

--- a/src/parser/css.ts
+++ b/src/parser/css.ts
@@ -159,7 +159,7 @@ export const getSymbolContent = (symbol: SymbolInformation) => {
   const fileContent = readFileSync(symbol.location.uri).toString();
   const document = TextDocument.create(
     symbol.location.uri,
-    "scss",
+    fileExt(symbol.location.uri) === "scss" ? "sass" : "css",
     1,
     fileContent
   );
@@ -168,6 +168,21 @@ export const getSymbolContent = (symbol: SymbolInformation) => {
     symbolContent,
     fileExt(symbol.location.uri) === "scss" ? "sass" : "css"
   );
+};
+
+export const getSymbolContentForHover = (symbol: SymbolInformation) => {
+  const fileContent = readFileSync(symbol.location.uri).toString();
+  const document = TextDocument.create(
+    symbol.location.uri,
+    fileExt(symbol.location.uri) === "scss" ? "sass" : "css",
+    1,
+    fileContent
+  );
+  const symbolContent = document.getText(symbol.location.range);
+  return {
+    content: symbolContent,
+    language: fileExt(symbol.location.uri) === "scss" ? "sass" : "css",
+  };
 };
 
 // This helper assumes the symbol you are trying to parse is a scss symbol

--- a/src/parser/css.ts
+++ b/src/parser/css.ts
@@ -155,6 +155,7 @@ export const scssSymbolMatcher = (
   return [];
 };
 
+// TODO: Deprecate this function
 export const getSymbolContent = (symbol: SymbolInformation) => {
   const fileContent = readFileSync(symbol.location.uri).toString();
   const document = TextDocument.create(
@@ -164,6 +165,7 @@ export const getSymbolContent = (symbol: SymbolInformation) => {
     fileContent
   );
   const symbolContent = document.getText(symbol.location.range);
+
   return new MarkdownString("", true).appendCodeblock(
     symbolContent,
     fileExt(symbol.location.uri) === "scss" ? "sass" : "css"
@@ -181,7 +183,7 @@ export const getSymbolContentForHover = (symbol: SymbolInformation) => {
   const symbolContent = document.getText(symbol.location.range);
   return {
     content: symbolContent,
-    language: fileExt(symbol.location.uri) === "scss" ? "sass" : "css",
+    language: fileExt(symbol.location.uri),
   };
 };
 

--- a/src/providers/ProviderFactory.ts
+++ b/src/providers/ProviderFactory.ts
@@ -8,6 +8,7 @@ import {
   filterSuffixedSelector,
   getSuffixesWithParent,
   getSymbolContent,
+  getSymbolContentForHover,
   parseCss,
   scssSymbolMatcher,
 } from "../parser/css";
@@ -178,6 +179,15 @@ export class ProviderFactory {
       );
     }
     return getSymbolContent(symbol);
+  }
+
+  public getSymbolContentForHover(symbol: SymbolInformation) {
+    if (!this.sourceCssFile) {
+      throw new Error(
+        "No source css file uri found. Did you create a ProviderFactory instance"
+      );
+    }
+    return getSymbolContentForHover(symbol);
   }
 
   public preProcessCompletions() {

--- a/src/providers/hover.ts
+++ b/src/providers/hover.ts
@@ -19,7 +19,8 @@ export const hoverProvider: (params: ProviderParams) => HoverProvider = () => {
         const matchedSelectors = await provider.getMatchedSelectors();
         if (matchedSelectors?.length) {
           const target = matchedSelectors[0];
-          const hoverContent = provider.getSymbolContent(target);
+          const { content, language } =
+            provider.getSymbolContentForHover(target);
           const filePath = target.location.uri
             .replace(Storage.workSpaceRoot ?? "", "")
             .replace(/^\//g, "");
@@ -28,7 +29,7 @@ export const hoverProvider: (params: ProviderParams) => HoverProvider = () => {
           const hover = new Hover(
             [
               new MarkdownString(`*_${filePath}:${linenum},${charnum}_*`),
-              hoverContent,
+              `\`\`\`${language} \n${content}\n\`\`\``,
             ],
             provider.getOriginWordRange()
           );

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -171,7 +171,7 @@ suite("Extension Test Suite", async () => {
         assert.notEqual(result, undefined);
         assert.equal(
           // @ts-ignore
-          result?.contents[1]?.value!.includes("test-container"),
+          result?.contents[1]?.includes("test-container"),
           true
         );
         StorageInstance.clear();
@@ -207,7 +207,7 @@ suite("Extension Test Suite", async () => {
           }
         )) as Hover;
         // @ts-ignore
-        assert.equal(result.contents[1].value.includes("&-test-suffix"), true);
+        assert.equal(result.contents[1].includes("&-test-suffix"), true);
       });
 
       test("should work for camel case selector values", async () => {
@@ -225,7 +225,7 @@ suite("Extension Test Suite", async () => {
           }
         )) as Hover;
         // @ts-ignore
-        assert.equal(result.contents[1].value.includes("testCamelCase"), true);
+        assert.equal(result.contents[1].includes("testCamelCase"), true);
       });
     });
 


### PR DESCRIPTION
Closes #19.

The code block on hover is formatted using classing markdown formatter. Hopefully this fixes any intermittent occurrence of syntax highlight issue

Tested this in development mode without any extensions