### PR TITLE
fix(parser): suffix selector without a hypen prefix is handled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+## [1.9.1]
+- Suffix selector without hypen prefix is handled - Fixes [82](https://github.com/Viijay-Kr/react-ts-css/issues/82)
 ## [1.9.0]
 - Javascript language support - Closes [#80](https://github.com/Viijay-Kr/react-ts-css/issues/80)
 ## [1.8.0]

--- a/examples/react-app/src/test/VariousSelectors/VariousSelectors.module.scss
+++ b/examples/react-app/src/test/VariousSelectors/VariousSelectors.module.scss
@@ -51,3 +51,15 @@
         display: flex;
     }
 }
+
+.camelCase {
+    display: flex;
+
+    &suffix {
+        display: contents;
+
+        &onemore {
+            display: contents;
+        }
+    }
+}

--- a/examples/react-app/src/test/VariousSelectors/VariousSelectors.tsx
+++ b/examples/react-app/src/test/VariousSelectors/VariousSelectors.tsx
@@ -1,3 +1,7 @@
+import styles from './VariousSelectors.module.scss';
 export const VariousSelector = () => {
-  return <div></div>;
+  return <div className={styles.camelCasesuffixonemore}>
+    <div className={styles.camelCasesuffix}></div>
+    <div className={styles.camelCase}></div>
+  </div>;
 };

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "react-ts-css",
   "displayName": "React CSS modules",
   "description": "React CSS modules - VS code extension for CSS modules support in React projects written in typescript.Supports Definitions, Hover , Completion Providers and Diagnostics",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "author": "Viijay-Kr",
   "publisher": "viijay-kr",
   "homepage": "https://github.com/Viijay-Kr/react-ts-css/blob/main/README.md",

--- a/src/parser/utils.ts
+++ b/src/parser/utils.ts
@@ -60,3 +60,27 @@ export const toVsCodeRange = (range: Range) => {
 export const toVsCodePosition = (range: Range) => {
   return new vscode.Position(range.start.line, range.start.character);
 };
+
+export const isSuffix = (selector: string) => {
+  return selector.startsWith("&-") || /^&[a-z|A-Z|0-9]/i.test(selector);
+};
+
+export const isSibling = (selector: string) => {
+  return selector.startsWith("&.");
+};
+
+export const isChild = (selector: string) => {
+  return selector.startsWith("& .");
+};
+
+export const isPsuedo = (selector: string) => {
+  return selector.indexOf(":") > -1;
+};
+
+export const isNormal = (selector: string) => {
+  return selector.startsWith(".");
+};
+
+export const isCombination = (selector: string) => {
+  return selector.indexOf(".") > -1;
+};

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -419,6 +419,26 @@ suite("Extension Test Suite", async () => {
         "flex-row-center"
       );
     });
+
+    test("should include camelCased suffixed selectors", async () => {
+      const document = await workspace.openTextDocument(SelectorCssModule);
+      await window.showTextDocument(document);
+      await StorageInstance.bootStrap();
+      const node = StorageInstance.cssModules.get(
+        normalizePath(SelectorCssModule)
+      );
+      assert.notEqual(node, undefined);
+      const selectors = node!.selectors;
+      assert.equal(selectors.get("camelCase")?.selector, "camelCase");
+      assert.equal(
+        selectors.get("camelCasesuffix")?.selector,
+        "camelCasesuffix"
+      );
+      assert.equal(
+        selectors.get("camelCasesuffixonemore")?.selector,
+        "camelCasesuffixonemore"
+      );
+    });
   });
 
   suite("Css language features", async () => {


### PR DESCRIPTION
Closes #82 

### Affected Language Features

SCSS Langauge service

### Additional Info

1. Suffix selector starting with `&` followed by any literal is handled now
2. Few functions have been created to help some utilities regarding selectors
