### PR TITLE
fix(store): performance issue fix due to code lens and references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,70 +1,116 @@
+## [1.9.3]
+
+- Disabling References and Code lens due to performance issue
+
 ## [1.9.2]
+
 - Fix newly added selector resolution issue
+
 ## [1.9.1]
+
 - Suffix selector without hypen prefix is handled - Fixes [82](https://github.com/Viijay-Kr/react-ts-css/issues/82)
+
 ## [1.9.0]
+
 - Javascript language support - Closes [#80](https://github.com/Viijay-Kr/react-ts-css/issues/80)
+
 ## [1.8.0]
+
 - Code Lens Provider integration for selector referenceses [#76](https://github.com/Viijay-Kr/react-ts-css/issues/76)
 - Some minor refactoring/renaming of Providers
+
 ## [1.7.0]
+
 - Reference Provider for Selectors - Closes [#74](https://github.com/Viijay-Kr/react-ts-css/issues/74)
   - Find reference of a selector across various TS/TSX modules
+
 ## [1.6.6]
+
 - readme updated to have the right setting name
+
 ## [1.6.5]
+
 - Update typescript clean up definitions plugin
   - Refinement of definitions results by the plugin - See [#1](https://github.com/Viijay-Kr/typescript-cleanup-defs/pull/1)
 - Changes to existings settings
   - `typecriptCleanUpDefs` is changed to `tsCleanUpDefs`
   - `cleanUpDefs` now takes a list of module extensions as default values
+
 ## [1.6.4]
+
 - Not ignoring node_modules from .vscodeignore - May be Closes [#68](https://github.com/Viijay-Kr/react-ts-css/issues/68)
+
 ## [1.6.3]
+
 - Maybe fix dependency injection of typescript-cleanup-definitions - May be Closes [#68](https://github.com/Viijay-Kr/react-ts-css/issues/68)
+
 ## [1.6.2]
+
 - Fixed Multiple Entries on Go to Definition
   - Unnecessary definition results from declaration modules for css classes can be avoided - Closes [#68](https://github.com/Viijay-Kr/react-ts-css/issues/68)
+
 ## [1.6.1]
+
 - CSS Parser
-  - Resolve selectors inside media queries - Closed [#66](https://github.com/Viijay-Kr/react-ts-css/issues/66) 
+  - Resolve selectors inside media queries - Closed [#66](https://github.com/Viijay-Kr/react-ts-css/issues/66)
+
 ## [1.6.0]
-- CSS Language Features 
+
+- CSS Language Features
   - Completion of CSS Variables
   - Go to Definitions of CSS variables
   - Syntax coloring for CSS variables
 - Minor Refactoring of providers into their own language providers
+
 ## [1.5.5]
+
 - Minor Refactorings of Providers
+
 ## [1.5.4]
-- No Diagnostic warning for empty string - Closes [#52](https://github.com/Viijay-Kr/react-ts-css/issues/52) 
+
+- No Diagnostic warning for empty string - Closes [#52](https://github.com/Viijay-Kr/react-ts-css/issues/52)
+
 ## [1.5.3]
+
 - Fix documentation typos
+
 ## [1.5.2]
+
 - Fix windows
+
 ## [1.5.1]
+
 - Ignore quick fix to ignore selector diagnostics temproarily - Closes [#52](https://github.com/Viijay-Kr/react-ts-css/issues/52)
+
 ## [1.5.0]
+
 - Less support is added from 1.5.0 (only modules with .module extension is supported)
 - Deeper suffix selectors are also resolved now
 
 ## [1.4.0]
+
 ## Code Actions For Diagnostics
+
 - 1.4.0 support Code Actions for Selector related Diagnostics - Closes [#45](https://github.com/Viijay-Kr/react-ts-css/issues/45)
-  - get  Code Action to change spelling of a misspelled selector by providing the closest match or add a new selector to the module
+  - get Code Action to change spelling of a misspelled selector by providing the closest match or add a new selector to the module
   - In the event of non existing selector ,get a Code Action to add the selector to the css module
 - Future versions will include code actions to fix all selector related warnings
 - Future versions will include code actions to fix all import related problems
-  
+
 ## [1.3.9]
+
 - Module not found for node module assets has been fixed - [#43](https://github.com/Viijay-Kr/react-ts-css/issues/43)
+
 ## [1.3.8]
+
 - Added useful diagnostics to non existing selectors and incorrect module import statements - Closes [#41](https://github.com/Viijay-Kr/react-ts-css/issues/41)
 - New Settings have been added to resolve diagnostics
   - `reactTsCSS.diagnostics` - Toggle to turn off diagnostics
   - `reactTsScss.tsconfig` - Base TS Config path in the project - Default './tsconfig.json'
   - `reactTsScss.baseDir` - Root directory of your project - Default 'src'
+
 ## [1.3.7]
+
 - This release contains Major updates to the parsing logic. This improves the following problems - [#37](https://github.com/Viijay-Kr/react-ts-css/issues/37)
   - Conflicts in suffixed selectors - [#18](https://github.com/Viijay-Kr/react-ts-css/issues/18)
   - Clean up of completion list by removing pusedo selectors
@@ -72,21 +118,35 @@
   - Memory optimization
   - Performance improvements - Altough this is an intuitive assumption
 - 1.3.7 removes the cyclic dependency mentioned [here](https://github.com/Viijay-Kr/react-ts-css#current-feasibilities) in point 4. From 1.3.7 cyclic dependencies injection will become no op
+
 ## [1.3.6]
+
 - Removes the start up message on activate - Closes [#38](https://github.com/Viijay-Kr/react-ts-css/issues/38)
+
 ## [1.3.5]
+
 - Update: The auto import feature now only includes modules in the same directory - closes [#20](https://github.com/Viijay-Kr/react-ts-css/issues/20#issuecomment-1379073856)
+
 ## [1.3.4]
+
 - Update doc to highlight the casing support
+
 ## [1.3.2]
-  - Auto import modules on completion selection of default export identifier - Closes [#20](https://github.com/Viijay-Kr/react-ts-css/issues/20)
+
+- Auto import modules on completion selection of default export identifier - Closes [#20](https://github.com/Viijay-Kr/react-ts-css/issues/20)
+
 ## [1.3.1]
- - Extensions Agnostic Syntax highlighting on hover using markdown syntax - Fixes [#19](https://github.com/Viijay-Kr/react-ts-css/issues/19)
+
+- Extensions Agnostic Syntax highlighting on hover using markdown syntax - Fixes [#19](https://github.com/Viijay-Kr/react-ts-css/issues/19)
 
 ## [1.3.0]
- - Workflows have been setup to automate jobs in github - **NO BREAKING CHANGE** - Closes [#23](https://github.com/Viijay-Kr/react-ts-css/issues/23) 
+
+- Workflows have been setup to automate jobs in github - **NO BREAKING CHANGE** - Closes [#23](https://github.com/Viijay-Kr/react-ts-css/issues/23)
+
 ## [1.2.3]
- - Fix broken activation logic when AST encounters an error - fixes [#21](https://github.com/Viijay-Kr/react-ts-css/issues/21)
+
+- Fix broken activation logic when AST encounters an error - fixes [#21](https://github.com/Viijay-Kr/react-ts-css/issues/21)
+
 ## [1.2.2]
 
 - Minor meta data update

--- a/README.md
+++ b/README.md
@@ -4,24 +4,24 @@
 <a href="https://marketplace.visualstudio.com/items?itemName=viijay-kr.react-ts-css" target="__blank"><img height="24" src="images/version.png" /></a>
 
 VS Code extension that enables CSS modules IntelliSense for your React projects written in TypeScript/Javascript.
-Currently supports CSS, SCSS, Less modules 
+Currently supports CSS, SCSS, Less modules
 
 This extension also supports CSS language features which are not supported by built in vscode [code css langauge fetures](https://github.com/microsoft/vscode-css-languageservice). Check [CSS language features](#cssscssless-langauge-features) for more info
 
 > This extension is unique in terms of support for major types of [Casings](#casings) and different types of CSS class selectors
-> 
+>
 > Different types of selectors are supported
+>
 > - Root selectors
 > - Nested selectors
 > - Suffixed selectors ([SCSS only](https://sass-lang.com/documentation/style-rules/parent-selector#adding-suffixes))
 > - Deeply nested suffix selectors
 >
 > Almost all project scaffolders such as Vite, Next.js and CRA add css module declaration to the project by injecting it in a `.d.ts` file (for instance inside `node_modules/vite/client.d.ts` added by Vite). TypeScript treats these definitions as definition provider for Style properties. This results in a useless definition result when VS Code `Go to Definition` is triggered. Check this [issue](https://github.com/Viijay-Kr/react-ts-css/issues/68).
-> 
+>
 > This extension gives you an option to eliminate the useless results by using the TypeScript plugin [typescript-cleanup-defs](https://www.npmjs.com/package/typescript-cleanup-definitions) that can filter out those definitions results. Check the plugin for more details.
 >
 > Override this plugin using the setting `reactTsScss.tsCleanUpDefs`
-
 
 <h2>Capabilities</h2>
 
@@ -35,14 +35,15 @@ This extension also supports CSS language features which are not supported by bu
   - [Variable Completion - **\[Only CSS\]**](#variable-completion---only-css)
   - [Variable Definitions - **\[Only CSS\]**](#variable-definitions---only-css)
   - [Syntax Colors and Presentation - **\[Only CSS\]**](#syntax-colors-and-presentation---only-css)
-  - [Reference Provider](#reference-provider)
-  - [Code Lens](#code-lens)
+  - [Reference Provider (**Experimental**)](#reference-provider)
+  - [Code Lens (**Experimental**))](#code-lens)
 - [Casings](#casings)
 - [Settings](#settings)
 - [Roadmap](#roadmap)
 - [Contribution](#contribution)
 
 ## TS/TSX|JS/JSX Language Features
+
 ### [Definitions](https://code.visualstudio.com/api/references/vscode-api#DefinitionProvider)
 
 - Go to any type of selector definition from your React components - [demo](https://github.com/Viijay-Kr/react-ts-css/tree/main/assets/definitions.gif)
@@ -51,7 +52,7 @@ This extension also supports CSS language features which are not supported by bu
 ### [Hover](https://code.visualstudio.com/api/references/vscode-api#HoverProvider)
 
 - Peek CSS properties of a selector on hover - [demo](https://github.com/Viijay-Kr/react-ts-css/tree/main/assets/hover.gif)
-  -  `reactTsCSS.peek` - setting for this feature
+  - `reactTsCSS.peek` - setting for this feature
 
 ### [Completions](https://code.visualstudio.com/api/references/vscode-api#HoverProvider)
 
@@ -60,6 +61,7 @@ This extension also supports CSS language features which are not supported by bu
   - `reactTsCSS.autoComplete` - setting for this feature
 
 ### [Diagnostics](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#diagnostic)
+
 - Useful diagnostics information are provided for missing selector - [demo](https://github.com/Viijay-Kr/react-ts-css/tree/main/assets/missing-selector.png)
 - Module not found error is also provided for non existing CSS modules - [demo](https://github.com/Viijay-Kr/react-ts-css/tree/main/assets/missing-module.png)
 - Settings to change diagnostics
@@ -76,34 +78,47 @@ This extension also supports CSS language features which are not supported by bu
   - `reactTsCSS.diagnostics` - setting for this feature
 
 ## CSS/SCSS/Less Langauge Features
- [Demo](https://github.com/Viijay-Kr/react-ts-css/tree/main/assets/css-variables.gif)
+
+[Demo](https://github.com/Viijay-Kr/react-ts-css/tree/main/assets/css-variables.gif)
+
 ### Variable Completion - **[Only CSS]**
-- Completion of variables across all the css modules 
+
+- Completion of variables across all the css modules
   - `reactTsCSS.cssAutoComplete` - setting for this feature
+
 ### [Variable Definitions](https://code.visualstudio.com/docs/languages/css#_go-to-declaration-and-find-references) - **[Only CSS]**
+
 - Definition of variables across all the css modules
-  -  `reactTsCSS.cssDefinitions` - setting for this feature
+  - `reactTsCSS.cssDefinitions` - setting for this feature
+
 ### [Syntax Colors and Presentation](https://code.visualstudio.com/docs/languages/css#_syntax-coloring-color-preview) - **[Only CSS]**
+
 - Color Presentations and color information for variables across all the css modules
   - `reactTsCSS.cssSyntaxColor` - setting for this feature
-> VS codes built in support for CSS Langauge is limited to the current active file.So the above features are limited to active file and hence any access to variables from different modules won't work until you install React CSS modules
+    > VS codes built in support for CSS Langauge is limited to the current active file.So the above features are limited to active file and hence any access to variables from different modules won't work until you install React CSS modules
 
-### [Reference Provider](https://code.visualstudio.com/docs/languages/typescript#_code-navigation) 
+### [Reference Provider](https://code.visualstudio.com/docs/languages/typescript#_code-navigation)
+
+> Experimental Feature. his is turned off till some performance problems are identified
+
 - Find all the references of a selector across various TS/TSX files - [Demo](assets/references.gif)
   - `reactTsCSS.references` - setting for this feature
 
 ### [Code Lens](https://code.visualstudio.com/api/language-extensions/programmatic-language-features#codelens-show-actionable-context-information-within-source-code)
+
+> Experimental feature . This is turned off till some performance problems are identified
+
 - Useful Code Lens context for selectors based on their references across component files - [Demo](assets/code-lens.gif)
 - A quick alternative to [reactTsCSS.references](#reference-provider)
   - `reactTsCSS.codelens` - setting for this feature
-  
+
 ## Casings
 
 This extensions supports selectors written in:
 
 1. snake_case
 2. PascalCase
-3. camelCase 
+3. camelCase
 4. kebab-case
 
 ## Settings
@@ -112,26 +127,26 @@ Defaults
 
 ```json
 {
-  "reactTsCSS.peek": true, 
-  "reactTsCSS.autoComplete": true, 
-  "reactTsCSS.autoImport": true, 
-  "reactTsCSS.definition": true, 
-  "reactTsCSS.references": true, 
-  "reactTsCSS.tsconfig":"./tsconfig.json", 
-  "reactTsCSS.baseDir":"src", 
-  "reactTsCSS.diagnostics":true, 
-  "reactTsCSS.cssAutoComplete":true, 
-  "reactTsCSS.cssDefinitions":true, 
-  "reactTsCSS.cssSyntaxColor":true, 
-  "reactTsCSS.tsCleanUpDefs":true, 
+  "reactTsCSS.peek": true,
+  "reactTsCSS.autoComplete": true,
+  "reactTsCSS.autoImport": true,
+  "reactTsCSS.definition": true,
+  "reactTsCSS.references": true,
+  "reactTsCSS.tsconfig": "./tsconfig.json",
+  "reactTsCSS.baseDir": "src",
+  "reactTsCSS.diagnostics": true,
+  "reactTsCSS.cssAutoComplete": true,
+  "reactTsCSS.cssDefinitions": true,
+  "reactTsCSS.cssSyntaxColor": true,
+  "reactTsCSS.tsCleanUpDefs": true,
   "reactTsCSS.cleanUpDefs": [
-      "*.module.css",
-      "*.module.scss",
-      "*.module.sass",
-      "*.module.less",
-      "*.module.styl"
+    "*.module.css",
+    "*.module.scss",
+    "*.module.sass",
+    "*.module.less",
+    "*.module.styl"
   ],
-  "reactTsCSS.codelens":true,
+  "reactTsCSS.codelens": true
 }
 ```
 
@@ -142,4 +157,5 @@ Defaults
 3. [Rename Provider](https://code.visualstudio.com/api/references/vscode-api#RenameProvider) - Rename a selector and get all the places updated
 
 ## Contribution
+
 Check out the contribution [guide](CONTRIBUTING.md)

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "react-ts-css",
   "displayName": "React CSS modules",
   "description": "React CSS modules - VS code extension for CSS modules support in React projects written in typescript.Supports Definitions, Hover , Completion Providers and Diagnostics",
-  "version": "1.9.2",
+  "version": "1.9.3",
   "author": "Viijay-Kr",
   "publisher": "viijay-kr",
   "homepage": "https://github.com/Viijay-Kr/react-ts-css/blob/main/README.md",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -137,15 +137,17 @@ export async function activate(context: ExtensionContext): Promise<void> {
       new CssDefinitionProvider()
     );
 
-    const _cssReferenceProvider = languages.registerReferenceProvider(
-      cssModulesDocumentSelector,
-      new ReferenceProvider()
-    );
+    // TODO: Disabling due to performance problems find the root cause
 
-    const _cssCodeLensProvider = languages.registerCodeLensProvider(
-      cssModulesDocumentSelector,
-      new ReferenceCodeLensProvider()
-    );
+    // const _cssReferenceProvider = languages.registerReferenceProvider(
+    //   cssModulesDocumentSelector,
+    //   new ReferenceProvider()
+    // );
+
+    // const _cssCodeLensProvider = languages.registerCodeLensProvider(
+    //   cssModulesDocumentSelector,
+    //   new ReferenceCodeLensProvider()
+    // );
 
     context.subscriptions.push(_selectorsCompletionProvider);
     context.subscriptions.push(_importsCompletionProvider);
@@ -155,8 +157,8 @@ export async function activate(context: ExtensionContext): Promise<void> {
     context.subscriptions.push(_codeActionsProvider);
     context.subscriptions.push(_cssColorProviders);
     context.subscriptions.push(_cssDefinitionProvider);
-    context.subscriptions.push(_cssReferenceProvider);
-    context.subscriptions.push(_cssCodeLensProvider);
+    // context.subscriptions.push(_cssReferenceProvider);
+    // context.subscriptions.push(_cssCodeLensProvider);
   } catch (e) {
     console.error(e);
     window.showWarningMessage(

--- a/src/store/Store.ts
+++ b/src/store/Store.ts
@@ -240,9 +240,12 @@ export class Store {
       const result = await parseCss(module);
       const cached = this._cssModules.get(module);
       if (result) {
-        this._cssModules.set(module, { ...result, references: cached?.references ?? new Set() });
+        this._cssModules.set(module, {
+          ...result,
+          references: cached?.references ?? new Set(),
+        });
       }
-    } catch (e) { }
+    } catch (e) {}
   }
 
   /**
@@ -268,7 +271,8 @@ export class Store {
         await this.setCssModules();
       }
       if (!this.tsModules.size) {
-        await this.setTsModules();
+        // Don't do this for every tsx file but rather only for active document until code lens is figured out.
+        // await this.setTsModules();
       }
       const document = this.activeTextEditor.document;
       const filePath = document.uri.fsPath;
@@ -298,7 +302,7 @@ export class Store {
           return this.provideDiagnostics();
         }
       }
-    } catch (e) { }
+    } catch (e) {}
   }
 
   /**

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -529,7 +529,7 @@ suite("Extension Test Suite", async () => {
       });
     });
 
-    suite("References", () => {
+    suite.skip("References", () => {
       test("provide references for a selector at a given position", async () => {
         const document = await workspace.openTextDocument(TestCssModulePath);
         await window.showTextDocument(document);
@@ -555,7 +555,7 @@ suite("Extension Test Suite", async () => {
       });
     });
 
-    suite("Code Lens", () => {
+    suite.skip("Code Lens", () => {
       test("provide reference code lens for a selectors in a document", async () => {
         const document = await workspace.openTextDocument(TestCssModulePath);
         await window.showTextDocument(document);


### PR DESCRIPTION
@karlhorky I'm disabling code lens and references provider temporarily to fix the performance problems.

I suspect it could be due to constant calculation of references and code lens trigger.


### Affected Language Features

CSS

