### PR TITLE
fix(diagnostics): ignoring dynamic selectors from dignostics collection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [1.9.4]
+
+- Dynamic References to selectors is not considered for diagnostics - Partially fixes [#86](https://github.com/Viijay-Kr/react-ts-css/issues/86)
+
 ## [1.9.3]
 
 - Disabling References and Code lens due to performance issue

--- a/examples/react-app/src/test/DynamicClasses/DynamicClasses.module.scss
+++ b/examples/react-app/src/test/DynamicClasses/DynamicClasses.module.scss
@@ -1,0 +1,3 @@
+.sm {
+    font-size: small;
+}

--- a/examples/react-app/src/test/DynamicClasses/DynamicClasses.tsx
+++ b/examples/react-app/src/test/DynamicClasses/DynamicClasses.tsx
@@ -1,0 +1,5 @@
+import styles from "./DynamicClasses.module.scss";
+
+export const DynamicClasses = ({ size }: { size: "sm" | "md" | "lg" }) => {
+  return <div className={styles[size]}></div>;
+};

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "react-ts-css",
   "displayName": "React CSS modules",
   "description": "React CSS modules - VS code extension for CSS modules support in React projects written in typescript.Supports Definitions, Hover , Completion Providers and Diagnostics",
-  "version": "1.9.3",
+  "version": "1.9.4",
   "author": "Viijay-Kr",
   "publisher": "viijay-kr",
   "homepage": "https://github.com/Viijay-Kr/react-ts-css/blob/main/README.md",

--- a/src/parser/v2/ts.ts
+++ b/src/parser/v2/ts.ts
@@ -19,6 +19,7 @@ export const isCssModuleDeclaration = (value: string) => {
 type Accessor = {
   property: StringLiteral | Identifier;
   object: Identifier; // Should always be one of sourceIdentfiers
+  isDynamic?: boolean;
 };
 export type ParserResult = {
   /** A list of default export identifier of a css module */
@@ -72,6 +73,12 @@ export const parseTypescript = (
                 accessors.push({
                   property: path.node.property,
                   object: path.node.object,
+                  isDynamic:
+                    isIdentifier(path.node.property) &&
+                    content.charAt(
+                      // @ts-expect-error
+                      (path.node.property.loc?.start.index! as number) - 1
+                    ) === "[",
                 });
               }
             }

--- a/src/providers/ts/diagnostics.ts
+++ b/src/providers/ts/diagnostics.ts
@@ -102,7 +102,7 @@ export class SelectorRelatedDiagnostics extends Diagnostics {
   renameSelector() {}
   runDiagnostics() {
     for (const accessor of this.parsedResult?.style_accessors ?? []) {
-      const { property, object } = accessor;
+      const { property, object, isDynamic } = accessor;
       const style_reference = this.parsedResult?.style_references.get(
         object.name
       );
@@ -119,6 +119,7 @@ export class SelectorRelatedDiagnostics extends Diagnostics {
           return "";
         })();
         if (
+          !isDynamic &&
           selector !== "" &&
           selectors &&
           !selectors.has(selector) &&

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -343,6 +343,20 @@ suite("Extension Test Suite", async () => {
         const diagnostics = await StorageInstance.bootStrap();
         assert.equal(diagnostics?.length, 2);
       });
+
+      test("should not provide dignostics for dynamic slectors", async () => {
+        const DynamicClasses = Uri.file(
+          path.join(
+            __dirname,
+            examplesLocation,
+            "react-app/src/test/DynamicClasses/DynamicClasses.tsx"
+          )
+        );
+        const document = await workspace.openTextDocument(DynamicClasses);
+        await window.showTextDocument(document);
+        const diagnostics = await StorageInstance.bootStrap();
+        assert.equal(diagnostics?.length, 0);
+      });
     });
   });
 


### PR DESCRIPTION

Partially Closes #86 

### Affected Language Features

* TSX
* Ts
* JSX
* JS

### Additional Info

This is an effort to partially fix the dynamic selector diagnostic warning as mentioned in the comment of #86.

This PR naively omits dynamic property accessors.

Selectors accessed through `[` operator is ignored if they happen to be a identifier type accessor.


