### PR TITLE
Fix-monorepo-poly-repo-aliases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [2.1.0]
+
+- TS Config path alias support
+  - Support in monorepo setup
+  - Support in polyrepo setup
+
 ## [2.0.0]
 
 - Fix open vsx publish job

--- a/examples/monorepo/apps/docs/pages/index.tsx
+++ b/examples/monorepo/apps/docs/pages/index.tsx
@@ -1,9 +1,11 @@
 import { Button } from "ui";
 
+import docStyles from '@styles/app.module.scss';
+
 export default function Docs() {
   return (
     <div>
-      <h1>Docs</h1>
+      <h1 className={docStyles['docs-title']}>Docs</h1>
       <Button />
     </div>
   );

--- a/examples/monorepo/apps/docs/styles/app.module.scss
+++ b/examples/monorepo/apps/docs/styles/app.module.scss
@@ -1,0 +1,3 @@
+.docs-title {
+    display: flex;
+}

--- a/examples/monorepo/apps/docs/tsconfig.json
+++ b/examples/monorepo/apps/docs/tsconfig.json
@@ -1,5 +1,22 @@
 {
   "extends": "tsconfig/nextjs.json",
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
-  "exclude": ["node_modules"]
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@styles/*": [
+        "styles/*"
+      ],
+      "@component-styles/*": [
+        "styles/components/*"
+      ]
+    }
+  },
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
 }

--- a/examples/monorepo/apps/docs/tsconfig.json
+++ b/examples/monorepo/apps/docs/tsconfig.json
@@ -8,7 +8,7 @@
       ],
       "@component-styles/*": [
         "styles/components/*"
-      ]
+      ],
     }
   },
   "include": [

--- a/examples/monorepo/apps/docs/tsconfig.json
+++ b/examples/monorepo/apps/docs/tsconfig.json
@@ -8,7 +8,7 @@
       ],
       "@component-styles/*": [
         "styles/components/*"
-      ],
+      ]
     }
   },
   "include": [

--- a/examples/monorepo/apps/web/package.json
+++ b/examples/monorepo/apps/web/package.json
@@ -12,16 +12,17 @@
     "next": "^13.1.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "sass": "^1.64.1",
     "ui": "*"
   },
   "devDependencies": {
     "@babel/core": "^7.0.0",
-    "eslint": "7.32.0",
-    "eslint-config-custom": "*",
-    "tsconfig": "*",
     "@types/node": "^17.0.12",
     "@types/react": "^18.0.22",
     "@types/react-dom": "^18.0.7",
+    "eslint": "7.32.0",
+    "eslint-config-custom": "*",
+    "tsconfig": "*",
     "typescript": "^4.5.3"
   }
 }

--- a/examples/monorepo/apps/web/pages/index.tsx
+++ b/examples/monorepo/apps/web/pages/index.tsx
@@ -1,9 +1,11 @@
 import { Button } from "ui";
+import styles from '@styles/app.module.scss';
+import buttonStyles from 'ui/Button/Button.module.css';
 
 export default function Web() {
   return (
     <div>
-      <h1>Web</h1>
+      <h1 className={styles.title}>Web</h1>
       <Button />
     </div>
   );

--- a/examples/monorepo/apps/web/pages/index.tsx
+++ b/examples/monorepo/apps/web/pages/index.tsx
@@ -1,6 +1,5 @@
 import { Button } from "ui";
 import styles from '@styles/app.module.scss';
-import buttonStyles from 'ui/Button/Button.module.css';
 
 export default function Web() {
   return (

--- a/examples/monorepo/apps/web/styles/app.module.scss
+++ b/examples/monorepo/apps/web/styles/app.module.scss
@@ -1,0 +1,3 @@
+.title {
+    display: flex;
+}

--- a/examples/monorepo/apps/web/styles/components/atomic/atoms.module.scss
+++ b/examples/monorepo/apps/web/styles/components/atomic/atoms.module.scss
@@ -1,0 +1,7 @@
+.atom-primary {
+    display: flex;
+}
+
+.atom-title {
+    display: flex;
+}

--- a/examples/monorepo/apps/web/styles/components/atomic/quantum/quantum.module.scss
+++ b/examples/monorepo/apps/web/styles/components/atomic/quantum/quantum.module.scss
@@ -1,0 +1,7 @@
+.qtm-primary {
+    display: flex;
+}
+
+.qtm-title {
+    display: flex;
+}

--- a/examples/monorepo/apps/web/styles/components/button.module.scss
+++ b/examples/monorepo/apps/web/styles/components/button.module.scss
@@ -1,0 +1,7 @@
+.btn-primary {
+    display: flex;
+}
+
+.btn-title {
+    display: flex;
+}

--- a/examples/monorepo/apps/web/tsconfig.json
+++ b/examples/monorepo/apps/web/tsconfig.json
@@ -1,5 +1,22 @@
 {
   "extends": "tsconfig/nextjs.json",
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
-  "exclude": ["node_modules"]
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@styles/*": [
+        "styles/*"
+      ],
+      "@component-styles/*": [
+        "styles/components/*"
+      ]
+    }
+  },
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
 }

--- a/examples/monorepo/package-lock.json
+++ b/examples/monorepo/package-lock.json
@@ -47,6 +47,7 @@
         "next": "^13.1.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "sass": "^1.64.1",
         "ui": "*"
       },
       "devDependencies": {
@@ -974,6 +975,18 @@
         "node": ">=4"
       }
     },
+    "node_modules/anymatch": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/argparse": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
@@ -1095,6 +1108,14 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
+    "node_modules/binary-extensions": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
+      "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -1189,6 +1210,32 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
+      "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ],
+      "dependencies": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
       }
     },
     "node_modules/client-only": {
@@ -2148,6 +2195,19 @@
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
     },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
@@ -2393,6 +2453,11 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immutable": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.1.tgz",
+      "integrity": "sha512-lj9cnmB/kVS0QHsJnYKD1uo3o39nrbKxszjnqS9Fr6NB7bZzW45U6WSGBPKXDL/CvDKqDNPA4r3DoDQ8GTxo2A=="
+    },
     "node_modules/import-fresh": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
@@ -2480,6 +2545,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dependencies": {
+        "binary-extensions": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/is-boolean-object": {
@@ -2957,6 +3033,14 @@
       "integrity": "sha512-dFSmB8fFHEH/s81Xi+Y/15DQY6VHW81nXRj86EMSL3lmuTmK1e+aT4wrFCkTbm+gSwkw4KpX+rT/pMM2c1mF+A==",
       "dev": true
     },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -3269,6 +3353,17 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
+    "node_modules/readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
+      }
+    },
     "node_modules/regenerator-runtime": {
       "version": "0.13.11",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
@@ -3389,6 +3484,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/sass": {
+      "version": "1.64.1",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.64.1.tgz",
+      "integrity": "sha512-16rRACSOFEE8VN7SCgBu1MpYCyN7urj9At898tyzdXFhC+a+yOX5dXwAR7L8/IdPJ1NB8OYoXmD55DM30B2kEQ==",
+      "dependencies": {
+        "chokidar": ">=3.0.0 <4.0.0",
+        "immutable": "^4.0.0",
+        "source-map-js": ">=0.6.2 <2.0.0"
+      },
+      "bin": {
+        "sass": "sass.js"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/scheduler": {
@@ -4731,6 +4842,15 @@
         "color-convert": "^1.9.0"
       }
     },
+    "anymatch": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "requires": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      }
+    },
     "argparse": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
@@ -4819,6 +4939,11 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
+    "binary-extensions": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
+      "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA=="
+    },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -4875,6 +5000,21 @@
         "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
         "supports-color": "^5.3.0"
+      }
+    },
+    "chokidar": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
+      "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
+      "requires": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "fsevents": "~2.3.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
       }
     },
     "client-only": {
@@ -5638,6 +5778,12 @@
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
     },
+    "fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "optional": true
+    },
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
@@ -5801,6 +5947,11 @@
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
       "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg=="
     },
+    "immutable": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.1.tgz",
+      "integrity": "sha512-lj9cnmB/kVS0QHsJnYKD1uo3o39nrbKxszjnqS9Fr6NB7bZzW45U6WSGBPKXDL/CvDKqDNPA4r3DoDQ8GTxo2A=="
+    },
     "import-fresh": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
@@ -5864,6 +6015,14 @@
       "integrity": "sha512-zB9CruMamjym81i2JZ3UMn54PKGsQzsJeo6xvN3HJJ4CAsQNB6iRutp2To77OfCNuoxspsIhzaPoO1zyCEhFOg==",
       "requires": {
         "has-bigints": "^1.0.1"
+      }
+    },
+    "is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "requires": {
+        "binary-extensions": "^2.0.0"
       }
     },
     "is-boolean-object": {
@@ -6186,6 +6345,11 @@
       "integrity": "sha512-dFSmB8fFHEH/s81Xi+Y/15DQY6VHW81nXRj86EMSL3lmuTmK1e+aT4wrFCkTbm+gSwkw4KpX+rT/pMM2c1mF+A==",
       "dev": true
     },
+    "normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="
+    },
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -6387,6 +6551,14 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
+    "readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "requires": {
+        "picomatch": "^2.2.1"
+      }
+    },
     "regenerator-runtime": {
       "version": "0.13.11",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
@@ -6456,6 +6628,16 @@
         "call-bind": "^1.0.2",
         "get-intrinsic": "^1.1.3",
         "is-regex": "^1.1.4"
+      }
+    },
+    "sass": {
+      "version": "1.64.1",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.64.1.tgz",
+      "integrity": "sha512-16rRACSOFEE8VN7SCgBu1MpYCyN7urj9At898tyzdXFhC+a+yOX5dXwAR7L8/IdPJ1NB8OYoXmD55DM30B2kEQ==",
+      "requires": {
+        "chokidar": ">=3.0.0 <4.0.0",
+        "immutable": "^4.0.0",
+        "source-map-js": ">=0.6.2 <2.0.0"
       }
     },
     "scheduler": {
@@ -6898,6 +7080,7 @@
         "next": "^13.1.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "sass": "^1.64.1",
         "tsconfig": "*",
         "typescript": "^4.5.3",
         "ui": "*"

--- a/examples/monorepo/packages/tsconfig/nextjs.json
+++ b/examples/monorepo/packages/tsconfig/nextjs.json
@@ -16,6 +16,7 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "preserve"
+   
   },
   "include": ["src", "next-env.d.ts"],
   "exclude": ["node_modules"]

--- a/examples/react-app/src/App.tsx
+++ b/examples/react-app/src/App.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import reactLogo from "./assets/react.svg";
 import "./App.css";
+import buttonStyles from 'styles/button.module.css';
 
 function App() {
   const [count, setCount] = useState(0);
@@ -14,6 +15,7 @@ function App() {
         <a href="https://reactjs.org" target="_blank">
           <img src={reactLogo} className="logo react" alt="React logo" />
         </a>
+        <button className={buttonStyles['btn-primary']}></button>
       </div>
       <h1>Vite + React</h1>
       <div className="card">

--- a/examples/react-app/src/styles/button.module.css
+++ b/examples/react-app/src/styles/button.module.css
@@ -1,0 +1,3 @@
+.btn-primary {
+    background: #000;
+}

--- a/examples/react-app/tsconfig.json
+++ b/examples/react-app/tsconfig.json
@@ -2,7 +2,11 @@
   "compilerOptions": {
     "target": "ESNext",
     "useDefineForClassFields": true,
-    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "lib": [
+      "DOM",
+      "DOM.Iterable",
+      "ESNext"
+    ],
     "allowJs": false,
     "skipLibCheck": true,
     "esModuleInterop": false,
@@ -15,7 +19,19 @@
     "isolatedModules": true,
     "noEmit": true,
     "jsx": "react-jsx",
+    "baseUrl": "src",
+    "paths": {
+      "styles/*": [
+        "styles/*"
+      ]
+    }
   },
-  "include": ["src"],
-  "references": [{ "path": "./tsconfig.node.json" }]
+  "include": [
+    "src"
+  ],
+  "references": [
+    {
+      "path": "./tsconfig.node.json"
+    }
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -94,19 +94,11 @@
           "default": true,
           "description": "Provide Diagnostics and Code Actions for non existing selectors and non existing css modules"
         },
-        "reactTsScss.tsconfig": {
-          "type": "array",
-          "title": "TS Config Path",
-          "default": [
-            "./tsconfig.json"
-          ],
-          "description": "A List of Locations of tsconfig.json inside the project. This config is used to resolve path aliases by the extension"
-        },
         "reactTsScss.tsconfigPathPrefix": {
           "type": "string",
           "title": "TS Config Path Prefix",
           "default": "",
-          "description": "TS Config path alias prefix. Set this to the matching prefix in your Ts Config path option"
+          "description": "TS Config path alias prefix. Set this to the matching prefix in your Ts Config path options"
         },
         "reactTsScss.baseDir": {
           "type": "string",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "react-ts-css",
   "displayName": "React CSS modules",
   "description": "React CSS modules - VS code extension for CSS modules support in React projects written in typescript.Supports Definitions, Hover , Completion Providers and Diagnostics",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "author": "Viijay-Kr",
   "publisher": "viijay-kr",
   "homepage": "https://github.com/Viijay-Kr/react-ts-css/blob/main/README.md",
@@ -93,12 +93,6 @@
           "type": "boolean",
           "default": true,
           "description": "Provide Diagnostics and Code Actions for non existing selectors and non existing css modules"
-        },
-        "reactTsScss.tsconfigPathPrefix": {
-          "type": "string",
-          "title": "TS Config Path Prefix",
-          "default": "",
-          "description": "TS Config path alias prefix. Set this to the matching prefix in your Ts Config path options"
         },
         "reactTsScss.baseDir": {
           "type": "string",

--- a/package.json
+++ b/package.json
@@ -95,10 +95,18 @@
           "description": "Provide Diagnostics and Code Actions for non existing selectors and non existing css modules"
         },
         "reactTsScss.tsconfig": {
-          "type": "string",
+          "type": "array",
           "title": "TS Config Path",
-          "default": "./tsconfig.json",
-          "description": "Location of tsconfig.json inside the project.This config is used to resolve path aliases by the extension"
+          "default": [
+            "./tsconfig.json"
+          ],
+          "description": "A List of Locations of tsconfig.json inside the project. This config is used to resolve path aliases by the extension"
+        },
+        "reactTsScss.tsconfigPathPrefix": {
+          "type": "string",
+          "title": "TS Config Path Prefix",
+          "default": "",
+          "description": "TS Config path alias prefix. Set this to the matching prefix in your Ts Config path option"
         },
         "reactTsScss.baseDir": {
           "type": "string",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -68,7 +68,6 @@ export async function activate(context: ExtensionContext): Promise<void> {
       Settings.definition = getSettings().get("definition");
       Settings.peekProperties = getSettings().get("peekProperties");
       Settings.cssAutoComplete = getSettings().get("cssAutoComplete");
-      Settings.tsconfigPathPrefix = getSettings().get("tsconfigPathPrefix");
       Settings.cssDefinitions = getSettings().get("cssDefinitions");
       Settings.diagnostics = getSettings().get("diagnostics");
       Settings.baseDir = getSettings().get("baseDir");

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -69,6 +69,7 @@ export async function activate(context: ExtensionContext): Promise<void> {
       Settings.peekProperties = getSettings().get("peekProperties");
       Settings.cssAutoComplete = getSettings().get("cssAutoComplete");
       Settings.tsconfig = getSettings().get("tsconfig");
+      Settings.tsconfigPathPrefix = getSettings().get("tsconfigPathPrefix");
       Settings.cssDefinitions = getSettings().get("cssDefinitions");
       Settings.diagnostics = getSettings().get("diagnostics");
       Settings.baseDir = getSettings().get("baseDir");

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -68,7 +68,6 @@ export async function activate(context: ExtensionContext): Promise<void> {
       Settings.definition = getSettings().get("definition");
       Settings.peekProperties = getSettings().get("peekProperties");
       Settings.cssAutoComplete = getSettings().get("cssAutoComplete");
-      Settings.tsconfig = getSettings().get("tsconfig");
       Settings.tsconfigPathPrefix = getSettings().get("tsconfigPathPrefix");
       Settings.cssDefinitions = getSettings().get("cssDefinitions");
       Settings.diagnostics = getSettings().get("diagnostics");

--- a/src/parser/Parser.ts
+++ b/src/parser/Parser.ts
@@ -32,9 +32,6 @@ export class Parser {
     } = this.context;
     const activeFileDir = path.dirname(filePath);
     const isRelativePath = source.startsWith(".");
-    const isTsConfigAlias = source.startsWith(
-      Settings.tsconfigPathPrefix ?? ""
-    );
     const doesModuleExists = (pathOfSource: string) =>
       sourceFiles.has(pathOfSource);
     if (isRelativePath) {

--- a/src/parser/Parser.ts
+++ b/src/parser/Parser.ts
@@ -32,7 +32,9 @@ export class Parser {
     } = this.context;
     const activeFileDir = path.dirname(filePath);
     const isRelativePath = source.startsWith(".");
-    const isTsConfigAlias = source.startsWith(Settings.tsconfigPathPrefix ?? "");
+    const isTsConfigAlias = source.startsWith(
+      Settings.tsconfigPathPrefix ?? ""
+    );
     const doesModuleExists = (pathOfSource: string) =>
       sourceFiles.has(pathOfSource);
     if (isRelativePath) {
@@ -42,12 +44,6 @@ export class Parser {
       if (doesModuleExists(relativePathOfSource)) {
         return relativePathOfSource;
       }
-    } else if (isTsConfigAlias) {
-      const aliasedModule = Store.resolveCssModuleAlias(source);
-      if (aliasedModule && Store.cssModules.has(aliasedModule)) {
-        return aliasedModule;
-      }
-
     } else {
       let absolutePathOfSource = normalizePath(
         path.resolve(workspaceRoot, source)
@@ -55,7 +51,12 @@ export class Parser {
       if (doesModuleExists(absolutePathOfSource)) {
         return absolutePathOfSource;
       }
+
       // as a last resort find the path using tsconfig.compilerOptions.base or base setting
+      const aliasedModule = Store.resolveCssModuleAlias(source);
+      if (aliasedModule && Store.cssModules.has(aliasedModule)) {
+        return aliasedModule;
+      }
       absolutePathOfSource = normalizePath(
         path.resolve(workspaceRoot, baseDir, source)
       );

--- a/src/providers/ts/diagnostics.ts
+++ b/src/providers/ts/diagnostics.ts
@@ -19,7 +19,7 @@ import { CssModuleExtensions, CSS_MODULE_EXTENSIONS } from "../../constants";
 import { Selector } from "../../parser/v2/css";
 import Store from "../../store/Store";
 import { normalizePath } from "../../path-utils";
-import Settings from '../../settings';
+import Settings from "../../settings";
 
 export type extended_Diagnostic = Diagnostic & {
   replace?: string;
@@ -100,7 +100,7 @@ export class SelectorRelatedDiagnostics extends Diagnostics {
       }
     }
   }
-  renameSelector() { }
+  renameSelector() {}
   runDiagnostics() {
     for (const accessor of this.parsedResult?.style_accessors ?? []) {
       const { property, object, isDynamic } = accessor;
@@ -190,8 +190,7 @@ export class ImportsRelatedDiagnostics extends Diagnostics {
               : path.resolve(this.activeFileDir, module)
           );
           let doesModuleExists = Store.cssModules.has(relativePath);
-          const isAliasImport = module.startsWith(Settings.tsconfigPathPrefix ?? "");
-          if (isAliasImport) {
+          if (!doesModuleExists) {
             const resolvedModule = Store.resolveCssModuleAlias(module);
             if (resolvedModule) {
               doesModuleExists = Store.cssModules.has(resolvedModule);

--- a/src/settings/index.ts
+++ b/src/settings/index.ts
@@ -55,14 +55,6 @@ export class Settings {
     workspace.getConfiguration(EXT_NAME).update("diagnostics", v);
   }
 
-  public get tsconfig(): string[] | undefined {
-    return getSettings().get("tsconfig");
-  }
-
-  public set tsconfig(v: string[] | undefined) {
-    workspace.getConfiguration(EXT_NAME).update("tsconfig", v);
-  }
-
   public get tsconfigPathPrefix(): string | undefined {
     return getSettings().get("tsconfigPathPrefix");
   }

--- a/src/settings/index.ts
+++ b/src/settings/index.ts
@@ -55,14 +55,6 @@ export class Settings {
     workspace.getConfiguration(EXT_NAME).update("diagnostics", v);
   }
 
-  public get tsconfigPathPrefix(): string | undefined {
-    return getSettings().get("tsconfigPathPrefix");
-  }
-
-  public set tsconfigPathPrefix(v: string | undefined) {
-    workspace.getConfiguration(EXT_NAME).update("tsconfigPathPrefix", v);
-  }
-
   public get baseDir(): string | undefined {
     return getSettings().get("baseDir");
   }

--- a/src/settings/index.ts
+++ b/src/settings/index.ts
@@ -55,12 +55,20 @@ export class Settings {
     workspace.getConfiguration(EXT_NAME).update("diagnostics", v);
   }
 
-  public get tsconfig(): string | undefined {
+  public get tsconfig(): string[] | undefined {
     return getSettings().get("tsconfig");
   }
 
-  public set tsconfig(v: string | undefined) {
+  public set tsconfig(v: string[] | undefined) {
     workspace.getConfiguration(EXT_NAME).update("tsconfig", v);
+  }
+
+  public get tsconfigPathPrefix(): string | undefined {
+    return getSettings().get("tsconfigPathPrefix");
+  }
+
+  public set tsconfigPathPrefix(v: string | undefined) {
+    workspace.getConfiguration(EXT_NAME).update("tsconfigPathPrefix", v);
   }
 
   public get baseDir(): string | undefined {

--- a/src/store/Store.ts
+++ b/src/store/Store.ts
@@ -270,7 +270,7 @@ export class Store {
   }
 
   resolveCssModuleAlias(source: string): string | undefined {
-    const activeFileDir = path.dirname(this.getActiveTextDocument().fileName);
+    const activeFileDir = normalizePath(path.dirname(this.getActiveTextDocument().fileName));
     for (const [, config] of this.tsConfig) {
       if (activeFileDir.includes(config.baseDir)) {
         const alias = normalizePath(path.dirname(source));

--- a/src/store/Store.ts
+++ b/src/store/Store.ts
@@ -109,14 +109,16 @@ export class Store {
   private async setCssModules() {
     const uri = window.activeTextEditor?.document?.uri;
     if (uri) {
-      const _uri = workspace.getWorkspaceFolder(uri)?.uri;
-      const workspaceRoot = _uri?.fsPath;
+      if (!this.workSpaceRoot) {
+        const _uri = workspace.getWorkspaceFolder(uri)?.uri;
+        const workspaceRoot = _uri?.fsPath;
+        this.workSpaceRoot = workspaceRoot;
+      }
       const glob = `**/*.{${CSS_MODULE_EXTENSIONS.map((e) =>
         e.replace(".", "")
       ).join(",")}}`;
-      this.workSpaceRoot = workspaceRoot;
       const files = await fsg(glob, {
-        cwd: workspaceRoot,
+        cwd: this.workSpaceRoot,
         ignore: ["node_modules", "build", "dist", "coverage"],
         absolute: true,
       });
@@ -324,10 +326,10 @@ export class Store {
         return;
       }
       // await this.saveTsConfig();
-      await this.saveTsConfigAutomatically();
       if (!this.cssModules.size) {
         await this.setCssModules();
       }
+      await this.saveTsConfigAutomatically();
       if (!this.tsModules.size) {
         // Don't do this for every tsx file but rather only for active document until code lens is figured out.
         // await this.setTsModules();
@@ -405,6 +407,7 @@ export class Store {
     this.workSpaceRoot = undefined;
     this._cssModules = new Map();
     this._tsModules = new Map();
+    this.tsConfig = new Map();
   }
 
   private provideDiagnostics() {


### PR DESCRIPTION
Closes #97 

### Affected Langauge Features

* Typescript
 
### Solution
* Save all the available TS configs in a list
* During module resolution and parser resolution go over all the paths of each config and try to resolve the absolute path of the aliased module

### Additional Info

Support for TS Config path aliases

Covers Monorepo setup and poly repo setup

