### PR TITLE
Disable-codelens-referenes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [2.3.1]
+
+- Disabling css code lens and references feature to prevent high CPU load - Closes [Viijay-Kr/react-ts-css#107](https://github.com/Viijay-Kr/react-ts-css/issues/107)
+
 ## [2.3.0]
 
 - Improved CSS langauge features

--- a/README.md
+++ b/README.md
@@ -100,13 +100,17 @@ This extension also supports CSS language features which are not supported by bu
 ### [Reference Provider](https://code.visualstudio.com/docs/languages/typescript#_code-navigation)
 
 - Find all the references of a selector across various TS/TSX files - [Demo](assets/references.gif)
+
   - `reactTsCSS.references` - setting for this feature
+
+  > This feature is turned OFF due to performance issues ([Viijay-Kr/react-ts-css#107](https://github.com/Viijay-Kr/react-ts-css/issues/107))
 
 ### [Code Lens](https://code.visualstudio.com/api/language-extensions/programmatic-language-features#codelens-show-actionable-context-information-within-source-code)
 
 - Useful Code Lens context for selectors based on their references across component files - [Demo](assets/code-lens.gif)
 - A quick alternative to [reactTsCSS.references](#reference-provider)
   - `reactTsCSS.codelens` - setting for this feature
+    > This feature is turned OFF due to performance issues ([Viijay-Kr/react-ts-css#107](https://github.com/Viijay-Kr/react-ts-css/issues/107))
 
 ## Casings
 
@@ -127,7 +131,7 @@ Defaults
   "reactTsCSS.autoComplete": true,
   "reactTsCSS.autoImport": true,
   "reactTsCSS.definition": true,
-  "reactTsCSS.references": true,
+  "reactTsCSS.references": false,
   "reactTsCSS.tsconfig": "./tsconfig.json",
   "reactTsCSS.baseDir": "src",
   "reactTsCSS.diagnostics": true,
@@ -142,7 +146,7 @@ Defaults
     "*.module.less",
     "*.module.styl"
   ],
-  "reactTsCSS.codelens": true
+  "reactTsCSS.codelens": false
 }
 ```
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "react-ts-css",
   "displayName": "React CSS modules",
   "description": "React CSS modules - VS code extension for CSS modules support in React projects written in typescript.Supports Definitions, Hover , Completion Providers and Diagnostics",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "author": "Viijay-Kr",
   "publisher": "viijay-kr",
   "homepage": "https://github.com/Viijay-Kr/react-ts-css/blob/main/README.md",
@@ -86,7 +86,7 @@
         },
         "reactTsScss.references": {
           "type": "boolean",
-          "default": true,
+          "default": false,
           "description": "Find all references of a selector across various TS/TSX files"
         },
         "reactTsScss.diagnostics": {
@@ -140,7 +140,7 @@
         "reactTsScss.codelens": {
           "type": "boolean",
           "title": "Code Lens for selectors",
-          "default": true,
+          "default": false,
           "description": "Codelens to references of selectors"
         }
       }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -136,26 +136,26 @@ export async function activate(context: ExtensionContext): Promise<void> {
       new CssDefinitionProvider()
     );
 
-    const _cssReferenceProvider = languages.registerReferenceProvider(
-      cssModulesDocumentSelector,
-      new ReferenceProvider()
-    );
+    // const _cssReferenceProvider = languages.registerReferenceProvider(
+    //   cssModulesDocumentSelector,
+    //   new ReferenceProvider()
+    // );
 
-    const _cssCodeLensProvider = languages.registerCodeLensProvider(
-      cssModulesDocumentSelector,
-      new ReferenceCodeLensProvider()
-    );
+    // const _cssCodeLensProvider = languages.registerCodeLensProvider(
+    //   cssModulesDocumentSelector,
+    //   new ReferenceCodeLensProvider()
+    // );
 
     context.subscriptions.push(_selectorsCompletionProvider);
     context.subscriptions.push(_importsCompletionProvider);
     context.subscriptions.push(_cssVariablesCompletion);
     context.subscriptions.push(_definitionProvider);
     context.subscriptions.push(_hoverProvider);
-    context.subscriptions.push(_codeActionsProvider);
+    context.subscriptions.push(_codeActionsProvider);        
     context.subscriptions.push(_cssColorProviders);
     context.subscriptions.push(_cssDefinitionProvider);
-    context.subscriptions.push(_cssReferenceProvider);
-    context.subscriptions.push(_cssCodeLensProvider);
+    // context.subscriptions.push(_cssReferenceProvider);
+    // context.subscriptions.push(_cssCodeLensProvider);
   } catch (e) {
     console.error(e);
     window.showWarningMessage(

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -565,7 +565,7 @@ suite("Extension Test Suite", async () => {
       });
     });
 
-    suite("References", () => {
+    suite.skip("References", () => {
       test("provide references for a selector at a given position", async () => {
         const document = await workspace.openTextDocument(TestCssModulePath);
         await window.showTextDocument(document);
@@ -590,7 +590,7 @@ suite("Extension Test Suite", async () => {
       });
     });
 
-    suite("Code Lens", () => {
+    suite.skip("Code Lens", () => {
       test("provide reference code lens for a selectors in a document", async () => {
         const document = await workspace.openTextDocument(TestCssModulePath);
         await window.showTextDocument(document);


### PR DESCRIPTION
Closes #107

### Affected Langauge Features

* CSS




### Additional Info

Recent release of 2.3.0 has caused huge performance bottleneck caused by code lens and references feature 

This PR disables the feature
