### PR TITLE
fix(scss): include selectors defined inside mixin references

### DIFF
--- a/.changeset/eight-camels-retire.md
+++ b/.changeset/eight-camels-retire.md
@@ -1,0 +1,5 @@
+---
+"react-ts-css": patch
+---
+
+intellisense for selectors declared inside mixin references

--- a/examples/react-app/src/test/VariousSelectors/VariousSelectors.module.scss
+++ b/examples/react-app/src/test/VariousSelectors/VariousSelectors.module.scss
@@ -67,3 +67,30 @@
 .new-selector-added {
     display: flex;
 }
+
+@mixin colorize($bg, $text) {
+    background-color: $bg;
+    color: $text;
+
+    .mixin-decl-selector {
+        color: #000;
+    }
+
+    @content;
+}
+
+@mixin md {
+    @content;
+}
+
+@include colorize(#000, #ccc) {
+    .mixin-reference-selector {
+        height: 100px;
+    }
+
+    @include md() {
+        .nested-mixin-reference-selector {
+            width: 200px;
+        }
+    }
+}

--- a/examples/react-app/src/test/VariousSelectors/VariousSelectors.tsx
+++ b/examples/react-app/src/test/VariousSelectors/VariousSelectors.tsx
@@ -4,5 +4,8 @@ export const VariousSelector = () => {
     <div className={styles.camelCasesuffix}></div>
     <div className={styles.camelCase}></div>
     <div className={styles['new-selector-added']}></div>
+    <div className={styles['mixin-decl-selector']}></div>
+    <div className={styles['mixin-reference-selector']}></div>
+    <div className={styles['nested-mixin-reference-selector']}></div>
   </div>;
 };

--- a/src/parser/v2/css.ts
+++ b/src/parser/v2/css.ts
@@ -5,7 +5,6 @@ import {
   Range as vscodeRange,
   Uri,
   TextDocument as vscode_TextDocument,
-  Color,
 } from "vscode";
 import {
   getCSSLanguageService,
@@ -13,15 +12,11 @@ import {
   TextDocument,
   Range,
   getLESSLanguageService,
-  Stylesheet as unsafe_Stylesheet,
   ColorInformation,
-  ColorPresentation,
 } from "vscode-css-languageservice";
 import { CssModuleExtensions } from "../../constants";
 import {
   CustomPropertyDeclaration,
-  Media,
-  MixinDeclaration,
   Node,
   NodeType,
   RuleSet,
@@ -180,16 +175,9 @@ export const getSelectors = (ast: Stylesheet, document: TextDocument) => {
         }
         break;
       }
-      case NodeType.MixinDeclaration:
-      case NodeType.Media:
-        break;
     }
-    const declarations = (node as RuleSet | MixinDeclaration | Media)
-      .declarations;
-    if (declarations) {
-      for (const child of declarations.getChildren()) {
-        resolveSelectors(child, node);
-      }
+    for (const child of node.getChildren()) {
+      resolveSelectors(child, node);
     }
   }
 

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -410,6 +410,14 @@ suite("Extension Test Suite", async () => {
       assert.equal(selectors.get("desktop")?.selector, "desktop");
       assert.equal(selectors.get("thirteen")?.selector, "thirteen");
       assert.equal(selectors.get("card")?.selector, "card");
+      assert.equal(
+        selectors.get("mixin-reference-selector")?.selector,
+        "mixin-reference-selector"
+      );
+      assert.equal(
+        selectors.get("nested-mixin-reference-selector")?.selector,
+        "nested-mixin-reference-selector"
+      );
     });
 
     test("should include selectors from placeholders", async () => {


### PR DESCRIPTION
Closes #130 

### Affected Langauge Features

SCSS


