### PR TITLE
feat(#182): enable references,codelens,rename,diagnostics only for modules

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -6,6 +6,7 @@ import {
   workspace,
   languages,
   extensions,
+  DocumentSelector,
 } from "vscode";
 import Settings, { EXT_NAME, getSettings } from "./settings";
 import Store from "./store/Store";
@@ -31,22 +32,22 @@ const documentSelector = [
   { scheme: "file", language: "javascript" },
 ];
 
-const cssDocumentSelector = [
+const cssDocumentSelector: DocumentSelector = [
   {
-    scheme: "file",
     language: "css",
+    pattern: "**/*.module.css",
   },
 ];
 
-const cssModulesDocumentSelector = [
+const cssModulesDocumentSelector: DocumentSelector = [
   ...cssDocumentSelector,
   {
-    scheme: "file",
     language: "scss",
+    pattern: "**/*.module.scss",
   },
   {
-    scheme: "file",
     language: "less",
+    pattern: "**/*.module.less",
   },
 ];
 
@@ -157,12 +158,12 @@ export async function activate(context: ExtensionContext): Promise<void> {
     );
 
     const _cssColorProviders = languages.registerColorProvider(
-      cssDocumentSelector,
+      { scheme: "file", language: "css" },
       new CssDocumentColorProvider(),
     );
 
     const _cssDefinitionProvider = languages.registerDefinitionProvider(
-      cssDocumentSelector,
+      { scheme: "file", language: "css" },
       new CssDefinitionProvider(),
     );
 

--- a/src/providers/diagnostics.ts
+++ b/src/providers/diagnostics.ts
@@ -237,8 +237,10 @@ export class ImportsRelatedDiagnostics extends Diagnostics {
 
 export class CSSDocumentDiagnostics extends Diagnostics {
   protected cssDiagnosticsProvider: CSSDiagnosticsProvider;
+  protected uri: Uri;
   constructor(options: DiagnosticsContext) {
     super(options);
+    this.uri = options.document.uri;
     this.cssDiagnosticsProvider = new CSSDiagnosticsProvider({
       providerKind: ProviderKind.Diagnostic,
       position: new Position(0, 0),
@@ -247,6 +249,8 @@ export class CSSDocumentDiagnostics extends Diagnostics {
   }
 
   async runDiagnostics() {
+    if (!this.uri.fsPath.includes("module")) return;
+
     this.diagnostics = await this.cssDiagnosticsProvider.provideDiagnostics();
   }
 }

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -34,12 +34,13 @@ import {
 import { parseCss } from "../../parser/v2/css";
 import {
   CSSCodeLensProvider,
-  CSSProvider,
   CSSReferenceProvider,
   CSSRenameProvider,
 } from "../../providers/css/CSSProvider";
 import { ProviderKind } from "../../providers/types";
 const examplesLocation = "../../../examples/";
+
+const testAppLocation = path.join(__dirname, examplesLocation, "react-app");
 
 function setWorskpaceFolder(app: string) {
   workspace.getWorkspaceFolder = () => {
@@ -365,6 +366,7 @@ suite("Extension Test Suite", async () => {
         await window.showTextDocument(document);
         const diagnostics = await Storage.bootstrap();
         assert.equal(diagnostics?.length, 1);
+        Storage.flushStorage();
       });
 
       test("should provide diagnostics for in correct css module import", async () => {
@@ -372,9 +374,10 @@ suite("Extension Test Suite", async () => {
         await window.showTextDocument(document);
         const diagnostics = await Storage.bootstrap();
         assert.equal(diagnostics?.length, 2);
+        Storage.flushStorage();
       });
 
-      test("should not provide dignostics for dynamic slectors", async () => {
+      test("should not provide dignostics for dynamic selectors", async () => {
         const DynamicClasses = Uri.file(
           path.join(
             __dirname,
@@ -383,6 +386,15 @@ suite("Extension Test Suite", async () => {
           ),
         );
         const document = await workspace.openTextDocument(DynamicClasses);
+        await window.showTextDocument(document);
+        const diagnostics = await Storage.bootstrap();
+        assert.equal(diagnostics?.length, 0);
+        Storage.flushStorage();
+      });
+
+      test("should not provide diagnostics for normal css files", async () => {
+        const AppCss = Uri.file(path.join(testAppLocation, "src/App.css"));
+        const document = await workspace.openTextDocument(AppCss);
         await window.showTextDocument(document);
         const diagnostics = await Storage.bootstrap();
         assert.equal(diagnostics?.length, 0);


### PR DESCRIPTION
Fixes #182 

### Affected Langauge Features
* CSS
* SCSS
* Less

### Additional Info

The following language features will only work for css/scss/less modules
1. References
2. Code lens
3. Rename Symbols
4. Diagnostics
