### PR TITLE
fix: path alias resolving

### DIFF
--- a/.changeset/pretty-points-drop.md
+++ b/.changeset/pretty-points-drop.md
@@ -1,0 +1,5 @@
+---
+"react-ts-css": patch
+---
+
+Fix path alias resolving

--- a/src/store/Store.ts
+++ b/src/store/Store.ts
@@ -221,13 +221,10 @@ export class Store {
       const paths = config.compilerOptions.paths;
       if (activeFileDir.includes(config.baseDir)) {
         let aliasPath = undefined;
-        const match = alias.match(/^@\w+/g);
-        const a = match?.[0];
         for (const [key, val] of Object.entries(paths ?? {})) {
-          const b = key.match(/^@\w+/g)?.[0];
-          if (b === a && !!b && !!a) {
-            const rest = alias.substring(a?.length);
-            aliasPath = path.join(val[0].replace("*", ""), rest);
+          const prefix = key.replace("*", "");
+          if (alias.startsWith(prefix)) {
+            aliasPath = alias.replace(prefix, val[0].replace("*", ""));
             break;
           }
         }


### PR DESCRIPTION
Closes #109 

### Affected Language Features

TypeScript

### Additional Info

Currently, the extension doesn't handle imports like `@/components/*`. This PR fixes this.
